### PR TITLE
Refactor to use only modular canjs libraries

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 !dist/
+doc/GREADME.md

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "can-control": "^3.0.0-pre.5",
-    "can-model": "^2.3.11",
+    "can-model": "^3.0.0-pre",
     "can-fixture": "^0.3.0",
     "cssify": "^0.6.0",
     "documentjs": "^0.4.2",
@@ -69,7 +69,7 @@
     "steal": "^0.14.0",
     "steal-qunit": "^0.1.1",
     "steal-tools": "^0.14.0",
-    "testee": "^0.2.4"
+    "testee": "^0.2.4",
     "generator-donejs": "^0.7.0",
     "donejs-cli": "^0.7.0",
     "can-ssr": "^0.11.6"

--- a/package.json
+++ b/package.json
@@ -54,17 +54,22 @@
     "npmAlgorithm": "flat"
   },
   "dependencies": {
-    "can": "^3.0.0-pre.0",
+    "can-list": "^3.0.0-pre.5",
+    "can-map": "^3.0.0-pre.8",
+    "can-util": "^3.0.0-pre.28",
     "jquery": "~2.2.1"
   },
   "devDependencies": {
+    "can-control": "^3.0.0-pre.5",
+    "can-model": "^2.3.11",
+    "can-fixture": "^0.3.0",
+    "cssify": "^0.6.0",
     "documentjs": "^0.4.2",
     "jshint": "^2.9.1",
-    "cssify": "^0.6.0",
     "steal": "^0.14.0",
     "steal-qunit": "^0.1.1",
     "steal-tools": "^0.14.0",
-    "testee": "^0.2.4",
+    "testee": "^0.2.4"
     "generator-donejs": "^0.7.0",
     "donejs-cli": "^0.7.0",
     "can-ssr": "^0.11.6"

--- a/src/can-map-attributes.js
+++ b/src/can-map-attributes.js
@@ -108,6 +108,21 @@ function applyAttributes (clss) {
 	};
 }
 applyAttributes(Map);
+// Check to see if can-model has been loaded but not set up for attributes.
+//  If not loaded, don't try to import it.  If it gets loaded
+//  later, it will be properly set up with attributes.
+const modelCheckPromise = System.normalize('can-model').then((normalizedModel) => {
+	if(System.has(normalizedModel)) {
+		return System.import(normalizedModel).then((CanModel) => {
+			if(!CanModel.attributes) {
+				applyAttributes(CanModel);
+			}
+			return Map;
+		});
+	} else {
+		return Map;
+	}
+});
 
 /**
  * @hide
@@ -155,4 +170,4 @@ Map.prototype.serialize = function (attrName) {
 	}
 };
 
-module.exports = exports = Map;
+module.exports = exports = modelCheckPromise;

--- a/src/can-map-attributes.js
+++ b/src/can-map-attributes.js
@@ -1,4 +1,4 @@
-var can = require('can-util');
+var can = require('can-util/namespace');
 var Map = require('can-map');
 require('can-map/map-helpers');
 require('can-list');
@@ -111,18 +111,9 @@ applyAttributes(Map);
 // Check to see if can-model has been loaded but not set up for attributes.
 //  If not loaded, don't try to import it.  If it gets loaded
 //  later, it will be properly set up with attributes.
-const modelCheckPromise = System.normalize('can-model').then((normalizedModel) => {
-	if(System.has(normalizedModel)) {
-		return System.import(normalizedModel).then((CanModel) => {
-			if(!CanModel.attributes) {
-				applyAttributes(CanModel);
-			}
-			return Map;
-		});
-	} else {
-		return Map;
-	}
-});
+if(typeof can.Model !== "undefined") {
+	applyAttributes(can.Model);
+}
 
 /**
  * @hide
@@ -170,4 +161,4 @@ Map.prototype.serialize = function (attrName) {
 	}
 };
 
-module.exports = exports = modelCheckPromise;
+module.exports = exports = Map;

--- a/src/can-map-attributes_test.js
+++ b/src/can-map-attributes_test.js
@@ -251,7 +251,7 @@ test('attr() should respect convert functions for lists when updating', function
 				members: 'ListTest.User.models'
 			}
 		}, {})
-	}
+	};
 	
 	ListTest.User.List = can.Model.List('ListTest_User_List', {}, {});
 	

--- a/src/can-map-attributes_test.js
+++ b/src/can-map-attributes_test.js
@@ -673,14 +673,14 @@ test('Convert Model using .model and .models (#293)', 5, function () {
 });
 test('Maximum call stack size exceeded with global models (#476)', function () {
 	stop();
-	var Character = Model.extend({
+	var Game, Character = Model.extend({
 		attributes: {
 			game: function () {
 				return Game.model.apply(Game, arguments);
 			}
 		}
 	}, {});
-	var Game = window.Game = Model.extend({
+	Game = window.Game = Model.extend({
 		attributes: {
 			characters: function () {
 				return Character.models.apply(Character, arguments);

--- a/src/demo/attributes-assocations.html
+++ b/src/demo/attributes-assocations.html
@@ -15,13 +15,15 @@
 <div id="contacts"></div>
 </div>
 <script id="demo-source" type='text/javascript' src='../../../node_modules/steal/steal.js' main="@empty">
-var can = require('can');
-require('can/map/attributes/attributes');
-require('can/model/model');
-require('can/util/fixture/fixture');
+var each = require('can-util/js/each/each');
+var $ = require('jquery');
+var attributes = require('can-map-attributes');
+var Map = require('can-map');
+var Model = require('can-model');
+var fixture = require('can-fixture');
 
 // simulate ajax response with fixtures
-can.fixture("/contacts.json", function(){
+fixture("/contacts.json", function(){
   return [{
     'id': 1,
     'name' : 'Justin Meyer',
@@ -49,7 +51,7 @@ can.fixture("/contacts.json", function(){
   }];
 })
 
-can.Model.convert.date = function(raw){
+Model.convert.date = function(raw){
   if(typeof raw == 'string'){
     var matches = raw.match(/(\d+)-(\d+)-(\d+)/);
       return new Date( +matches[1],
@@ -61,7 +63,7 @@ can.Model.convert.date = function(raw){
 };
 
 // A task model that has a date
-var Task = can.Model({
+var Task = Model({
   attributes : {
     due : 'date'
   }
@@ -73,7 +75,7 @@ var Task = can.Model({
 });
 
 // A contact model that has many tasks
-var Contact = can.Model({
+var Contact = Model({
   attributes : {
     birthday : 'date',
     tasks: Task
@@ -92,15 +94,15 @@ var Contact = can.Model({
 });
 
 // Get all contacts and put them on the page
-Contact.findAll({}).done(function(contacts){
+Contact.findAll({}).then(function(contacts){
   var contactsEl = can.$('#contacts');
 
-  can.each(contacts, function(contact){
-    var li = can.$('<li>')
+  each(contacts, function(contact){
+    var li = $('<li>')
       .html(contact.name + " "+ contact.ageThisYear())
       .appendTo(contactsEl);
 
-    var ul = can.$("<ul>");
+    var ul = $("<ul>");
     var tasks = contact.attr('tasks')
 
     if(tasks){


### PR DESCRIPTION
I'm unsure whether this is the best way to approach it, but I <s>removed the direct reference to can-model within the code</s> used a conditional `System.normalize` -> `System.has` -> `System.import` flow to make can-model an optional lib.  It works fine <s>as long as `can-map-attributes` is stealt before `can-model` but I don't like having order enforced like that</s> with the tests.

All tests are passing locally but they depend on https://github.com/canjs/can-model/pull/4 being accepted by can-model (because can-map and canjs/map produce different constructors, & until #4 goes through, can-model is using canjs/map). [UPDATE: can-model#4 is merged]