### PR TITLE
Remove cssify as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,16 +23,6 @@
     "develop": "can-serve --static --develop --port 8080"
   },
   "main": "dist/cjs/can-map-attributes",
-  "browser": {
-    "transform": [
-      "cssify"
-    ]
-  },
-  "browserify": {
-    "transform": [
-      "cssify"
-    ]
-  },
   "keywords": [
     "canjs",
     "donejs",
@@ -65,7 +55,6 @@
     "can-control": "^3.0.0-pre.5",
     "can-model": "^3.0.0-pre",
     "can-fixture": "^0.3.0",
-    "cssify": "^0.6.0",
     "documentjs": "^0.4.2",
     "jshint": "^2.9.1",
     "steal": "^0.14.0",


### PR DESCRIPTION
cssify is not used in this package and by including it, it breaks
browserify.